### PR TITLE
Refactor: delete cart 데코레이터 반영

### DIFF
--- a/BackEnd/view/order_view.py
+++ b/BackEnd/view/order_view.py
@@ -75,7 +75,7 @@ class CartView(MethodView):
     
     @login_required
     @validate_params(
-        Param('product_option_id', JSON, int, required=True),
+        Param('cart_id', JSON, int, required=True),
         Param('quantity', JSON, int, required=True)
     )
     def patch(*args):
@@ -102,23 +102,21 @@ class CartView(MethodView):
             if connection is not None:
                 connection.close()
     
-    # 데코레이터 선언 예정
+    @login_required
     @validate_params(
-        Param('user_id', JSON, int, required=True), # 테스트용 user_id
-        Param('product_option_id', JSON, int, required=True)
+        Param('cart_id', JSON, int, required=True)
     )
     def delete(*args):
         cart_service = CartService()
+        connection   = None
 
-        connection = None
         try:
+            filters               = request.json
+            filters["account_id"] = g.account_info["account_id"]
+
             connection = connect_db()
 
-            # user = request.user (데코레이터 사용시 user 선언 방법)
-            
-            data = request.json
-
-            result = cart_service.delete_cart_product(data, connection)
+            result     = cart_service.delete_cart_product(connection, filters)
 
             connection.commit()
 


### PR DESCRIPTION
post, get 을 제외한 patch, delete 에서 프론트로부터 cart_id를 받도록 코드 수정
update_cart_history_end_time -> product_option_id 가 아닌 cart_id 를 받도록 수정
update_cart_history_information -> product_option_id 가 아닌 cart_id 를 받도록 수정
update_cate_history_information -> quantity, delete 를 받을때, 안 받을때 모두 처리하도록 수정